### PR TITLE
Set OpenMS version 3.1.0

### DIFF
--- a/workflow/envs/openms.yaml
+++ b/workflow/envs/openms.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - pip:
     - ipython
-  - openms
+  - openms=3.1.0
   - mono
   - python-dateutil
   - pandas=1.2.4

--- a/workflow/envs/pyopenms.yaml
+++ b/workflow/envs/pyopenms.yaml
@@ -7,5 +7,5 @@ dependencies:
   - pip
   - pip:
     - ipython
-  - pyopenms
+  - pyopenms=3.1.0
   - pyteomics


### PR DESCRIPTION
With the recent changes in OpenMS (SiriusAdapter reworked to SiriusExport) this workflow fails with the latest nightly builds.